### PR TITLE
Make ConnectorPinout=Plus instead of Unknown on Pi Zero W

### DIFF
--- a/RaspberrySharp/System/Board.cs
+++ b/RaspberrySharp/System/Board.cs
@@ -283,6 +283,7 @@ namespace RaspberrySharp.System
                 case Model.APlus:
                 case Model.B2:
                 case Model.Zero:
+                case Model.ZeroW:
                 case Model.B3:
                 case Model.B3Plus:
                 case Model.ComputeModule3:


### PR DESCRIPTION
The Pi Zero appeared as ConnectorPinout=Unknown so I adjusted it to show Plus instead.